### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Tailscale Network Topology Dashboard
+
+This repository contains a prototype dashboard that shows the topology of a Tailscale network. The app is written in **TypeScript** and consists of a React front end and an Express back end. In development the server uses an in-memory data store but the schema is ready for PostgreSQL using Drizzle ORM.
+
+## Features
+- Interactive visualization of devices and their connections
+- Live network updates over WebSockets
+- REST API for device and network data
+- Typed shared schema between client and server
+
+## Getting started
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server with hot reload:
+   ```bash
+   npm run dev
+   ```
+3. The app will be available at [http://localhost:5000](http://localhost:5000).
+
+### Useful scripts
+- `npm run build` – build client and server for production
+- `npm start` – run the compiled app from `dist`
+- `npm run check` – type check the project
+- `npm run db:push` – push database schema changes when PostgreSQL is configured
+
+## Repository structure
+- `client/` – React code and UI components
+- `server/` – Express server, API routes and WebSocket logic
+- `shared/` – Types and schema shared between client and server
+
+## Project timeline
+- **Jul 5, 2025** – Repository initialized
+- **Jul 5, 2025** – Set up initial project structure and UI components
+- **Jul 5, 2025** – Added README documentation
+
+## Roadmap
+The next areas of work are tracked here at a high level:
+- [ ] Persist data to a PostgreSQL instance instead of memory
+- [ ] Display device details in a modal with management actions
+- [ ] Add authentication and user accounts
+- [ ] Improve real-time updates and network statistics
+- [ ] Add automated tests and continuous integration

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,16 @@
+# Client
+
+The client is a Vite-powered React application written in TypeScript. It renders the network topology and subscribes to WebSocket updates from the server.
+
+## Development
+Run the entire app from the project root:
+```bash
+npm run dev
+```
+Vite will serve the frontend at `/` and proxy API requests to the backend.
+
+## Next tasks
+- [ ] Show device details in a modal dialog
+- [ ] Display real-time network statistics in the sidebar
+- [ ] Improve the force-directed layout for the graph
+- [ ] Add unit tests for components and hooks

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,16 @@
+# Server
+
+The backend is an Express application that exposes REST APIs and a WebSocket endpoint. In development it stores data in memory and periodically simulates network changes.
+
+## Running
+Start both frontend and backend together from the project root:
+```bash
+npm run dev
+```
+The server listens on port **5000** for HTTP and WebSocket traffic.
+
+## Next tasks
+- [ ] Persist devices and connections in PostgreSQL
+- [ ] Secure APIs with authentication middleware
+- [ ] Expose REST endpoints for managing devices
+- [ ] Refine network simulation and metrics


### PR DESCRIPTION
## Summary
- expand the main README with a short overview, how to run the project, and a roadmap
- describe development steps in `client/README.md`
- outline backend tasks in `server/README.md`

## Testing
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868bf4b13248322bf7b2d001053b47f